### PR TITLE
fix: update large propellant to 12000000

### DIFF
--- a/pages/ship_calc.vue
+++ b/pages/ship_calc.vue
@@ -565,7 +565,7 @@ export default {
                     id: 'PT3',
                     title: 'SHIP_CALC.PROPELLANT.PROPELLANT_T3',
                     count: 0,
-                    propellant: 9000000,
+                    propellant: 12000000,
                     mass: 24413
                 }
             ],


### PR DESCRIPTION
Large propellant tanks have had thier capacity changed to 12,000,000 in the update a few months ago